### PR TITLE
Ajout de dépendances

### DIFF
--- a/kde5-extra/kdenlive/Pkgfile
+++ b/kde5-extra/kdenlive/Pkgfile
@@ -1,4 +1,4 @@
-# Depends on: kf5-knewstuff kf5-kplotting kf5-knotifyconfig kf5-kded kf5-kfilemetadata qt-webkit mlt xorg-glu sdl-image hicolor-icon-theme qt-base kf5-extra-cmake-modules kf5-kdoctools v4l-utils ffmpeg cdrkit libdv plasma-desktop
+# Depends on: breeze-gtk qt-quickcontrols frei0r-plugins kf5-knewstuff kf5-kplotting kf5-knotifyconfig kf5-kded kf5-kfilemetadata qt-webkit mlt xorg-glu sdl-image hicolor-icon-theme qt-base kf5-extra-cmake-modules kf5-kdoctools v4l-utils ffmpeg cdrkit libdv plasma-desktop
 
 description="A non-linear video editor for Linux using the MLT video framework"
 url="http://www.kdenlive.org/"


### PR DESCRIPTION
Dépendances manquantes à l'utilisation d' environnement  hors KDE + rajout des effets frei0r-plugins.
Attention, je n'ai pas fait la compil en locale, la compile de kdenlive 17.04.2 foire chez moi. Ces dépendances que je rajoute dans la recette sont installé sur ma machine après l'installation du Kdenlive branche "current"